### PR TITLE
Add kibela-markdown-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,7 +16,7 @@
     M-x kibela-note-new
     #+end_example
 
-    で新しい記事を書くための gfm-mode のバッファが用意されます。
+    で新しい記事を書くための kibela-markdown-mode のバッファが用意されます。
     バッファを開く前に記事の title を聞かれます。
 
     また
@@ -30,7 +30,7 @@
     記事を書いた後は
 
     #+begin_example
-    M-x kibela-note-create
+    C-c p
     #+end_example
 
     で Kibela に投稿できます。
@@ -41,12 +41,12 @@
     (kibela-note-show ID)
     #+end_example
 
-    で記事を取得し gfm-mode で表示します。
+    で記事を取得し kibela-markdown-mode で表示します。
 
     表示されたバッファは編集可能なので、編集後に
 
     #+begin_example
-    M-x kibela-note-update
+    C-c p
     #+end_example
 
     を実行することで記事を更新できます。

--- a/kibela-markdown-mode.el
+++ b/kibela-markdown-mode.el
@@ -1,0 +1,52 @@
+;;; kibela-markdown.el --- major-mode for kibela markdown  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Mugijiru
+
+;; Author: mugijiru <106833+mugijiru@users.noreply.github.com>
+;; Maintainer: mugijiru <106833+mugijiru@users.noreply.github.com>
+;; URL: https://github.com/mugijiru/emacs-kibela
+;; Version: 0.1.0
+;; Package-Requires: ((kibela "0.1.0") (markdown-mode "2.5"))
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'markdown-mode)
+
+(defun kibela-markdown-post ()
+  (interactive)
+  (if kibela-note-base
+      (kibela-note-update)
+    (kibela-note-create)))
+
+(defvar kibela-markdown-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map markdown-mode-map)
+    (define-key map (kbd "C-c p") 'kibela-markdown-post)
+    map)
+  "Keymap for `kibela-markdown-mode'.
+See also `markdown-mode-map'.")
+
+(define-derived-mode kibela-markdown-mode gfm-mode "Kibela Markdown"
+  "Major mode for editing Kibela Markdown files."
+  (use-local-map kibela-markdown-mode-map))
+
+(provide 'kibela-markdown-mode)
+;;; kibela-markdown.el ends here

--- a/kibela.el
+++ b/kibela.el
@@ -29,6 +29,7 @@
 (require 'graphql)
 (require 'request)
 (require 'json)
+(require 'kibela-markdown-mode)
 
 (defcustom kibela-team nil
   "Kibela team name for login."
@@ -208,7 +209,7 @@
     (kibela-store-default-group)
     (switch-to-buffer buffer)
     (insert (concat "# " title "\n\n"))
-    (gfm-mode)))
+    (kibela-markdown-mode)))
 
 (defun kibela--new-note-from-template (template)
   "記事を作成するバッファを用意する"
@@ -219,7 +220,7 @@
          (buffer (get-buffer-create "*Kibela* newnote")))
     (switch-to-buffer buffer)
     (insert (concat "# " title "\n\n" content))
-    (gfm-mode)
+    (kibela-markdown-mode)
     (setq kibela-note-template template)))
 
 (defun kibela-note-create ()
@@ -303,7 +304,7 @@
                          (buffer (get-buffer-create (concat "*Kibela* " id))))
                     (switch-to-buffer buffer)
                     (insert (concat "# " title "\n\n" content))
-                    (gfm-mode)
+                    (kibela-markdown-mode)
                     (setq kibela-note-base
                           `(("title" . ,title)
                             ("content" . ,content)


### PR DESCRIPTION
Kibela の記事を編集する時の専用のモードを追加した。

なお現在は gfm-mode をベースにしていて
C-c p の kibela-markdown-post というコマンドを追加してるだけである