### PR TITLE
refactor: Extract kibela--store-default-group-sucess

### DIFF
--- a/kibela-test.el
+++ b/kibela-test.el
@@ -1,0 +1,9 @@
+(require 'kibela)
+(require 'ert)
+
+(ert-deftest test-kibela--store-default-group-success ()
+  (setq-local kibela-default-group nil)
+  (let ((expect '((id . "TestId") (name . "Test group")))
+        (response '((data (defaultGroup (id . "TestId") (name . "Test group"))))))
+    (kibela--store-default-group-success :data response)
+    (should (equal expect kibela-default-group))))

--- a/kibela.el
+++ b/kibela.el
@@ -145,19 +145,21 @@
                             (pp args)
                             (message "Got error: %S" error-thrown))))))
 
+(cl-defun kibela--store-default-group-success (&key data &allow-other-keys)
+  (let* ((response-data (assoc-default 'data data))
+         (group (assoc-default 'defaultGroup response-data)))
+    (setq kibela-default-group group)))
+
 (defun kibela-store-default-group ()
   "デフォルトの投稿先グループを取得する"
-  (cond (kibela-default-group
-         nil)
-        (t
-         (let* ((query kibela-graphql-query-default-group))
-           (kibela--request query
-                            nil
-                            (cl-function
-                             (lambda (&key data &allow-other-keys)
-                               (let* ((response-data (assoc-default 'data data))
-                                      (group (assoc-default 'defaultGroup response-data)))
-                                 (setq kibela-default-group group)))))))))
+  (cond
+   (kibela-default-group
+    nil)
+   (t
+    (let* ((query kibela-graphql-query-default-group))
+      (kibela--request query
+                       nil
+                       #'kibela--store-default-group-success)))))
 
 (defun kibela-build-collection-from-note-templates (note-templates)
   (mapcar (lambda (note-template)


### PR DESCRIPTION
default group のリクエストが成功した時の処理を分離した

他の処理のリクエスト成功部分も切り出そうとしたが
バッファを使ってたり中で別の関数を叩いていたりして
mock とかが必要そうなので面倒で今回はやめておいた