### PR TITLE
C-c letter はユーザー用に予約されているので remap

### DIFF
--- a/kibela-markdown-mode.el
+++ b/kibela-markdown-mode.el
@@ -39,7 +39,7 @@
 (defvar kibela-markdown-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map markdown-mode-map)
-    (define-key map (kbd "C-c p") 'kibela-markdown-post)
+    (define-key map (kbd "C-c C-c C-c") 'kibela-markdown-post)
     map)
   "Keymap for `kibela-markdown-mode'.
 See also `markdown-mode-map'.")


### PR DESCRIPTION
なお C-c C-c は prefix として markdown-mode に予約されているので
C-c C-c C-c というキーバインドにしておいた