### PR TITLE
test: Add macro kibela-test--use-response-stub

### DIFF
--- a/kibela-test.el
+++ b/kibela-test.el
@@ -19,8 +19,7 @@
 (ert-deftest test-kibela-store-default-group/success ()
   (let ((kibela-default-group nil)
         (response '((data (defaultGroup (id . "TestId") (name . "Test group"))))))
-    (kibela-test--use-response-stub
-      response
+    (kibela-test--use-response-stub response
       (kibela-store-default-group)
       (should (equal (symbol-value 'kibela-default-group)
                      '((id . "TestId") (name . "Test group")))))))
@@ -55,8 +54,7 @@
 (ert-deftest test-kibela-note-new/when-saved-default-group ()
   (let ((kibela-default-group '((id . "TestId") (name . "Saved Test group")))
         (note-title "Test note"))
-    (noflet ((kibela--request (query variables success)
-                              (error "Unexpected request call")))
+    (kibela-test--use-response-stub nil
       (with-temp-buffer
         (kibela-note-new note-title)
         (should (string-equal (buffer-name) "*Kibela* newnote"))
@@ -67,9 +65,10 @@
 (ert-deftest test-kibela-note-new/fetch-default-group ()
   (let* ((kibela-default-group nil)
          (group '((id . "TestId") (name . "Fetched Test group")))
+         (default-group (append '(defaultGroup) group))
+         (response `((data ,default-group)))
          (note-title "Test note"))
-    (noflet ((kibela--request (query variables success)
-                              (setq kibela-default-group group)))
+    (kibela-test--use-response-stub response
       (with-temp-buffer
         (kibela-note-new note-title)
         (should (string-equal (buffer-name) "*Kibela* newnote"))

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -2,6 +2,13 @@
 (require 'ert)
 (require 'noflet)
 
+(defmacro kibela-test--use-response-stub (response &rest body)
+  (declare (indent defun))
+  `(noflet ((request () (error "Unexpected request call")) ;; Don't send request
+            (kibela--request (query variables success)
+                             (apply success :data `(,response))))
+     ,@body))
+
 (ert-deftest test-kibela--store-default-group-success ()
   (setq-local kibela-default-group nil)
   (let ((expect '((id . "TestId") (name . "Test group")))
@@ -12,8 +19,8 @@
 (ert-deftest test-kibela-store-default-group/success ()
   (let ((kibela-default-group nil)
         (response '((data (defaultGroup (id . "TestId") (name . "Test group"))))))
-    (noflet ((kibela--request (query variables success)
-                              (apply success :data `(,response))))
+    (kibela-test--use-response-stub
+      response
       (kibela-store-default-group)
       (should (equal (symbol-value 'kibela-default-group)
                      '((id . "TestId") (name . "Test group")))))))


### PR DESCRIPTION
noflet を使ってリクエスト周りを置き換える処理が複数あったので
macro を使って共通化しておいた