### PR TITLE
テンプレートが関わる部分の修正 & テストを追加した

### DIFF
--- a/Eask
+++ b/Eask
@@ -17,4 +17,5 @@
 (depends-on "request" "0.3.3")
 (depends-on "markdown-mode" "2.5")
 (development
- (depends-on "noflet"))
+ (depends-on "noflet")
+ (depends-on "with-simulated-input"))

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -1,7 +1,7 @@
 (require 'kibela)
 (require 'ert)
 (require 'noflet)
-(require 'ert-x)
+(require 'with-simulated-input)
 
 (defmacro kibela-test--use-response-stub (response &rest body)
   (declare (indent defun))
@@ -185,7 +185,7 @@ kibela--new-note-from-template に渡すことを確認する."
          (completing-read-function #'completing-read-default))
     (kibela-test--use-response-stub response
       (with-temp-buffer
-        (ert-simulate-keys (kbd "ba TAB RET")
+        (with-simulated-input "ba TAB RET"
           (kibela-note-new-from-template)
           (should (string-equal (buffer-name) "*Kibela* newnote"))
           (should (string-equal header-line-format "Home"))

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -78,6 +78,49 @@
 
 ;;; template tests
 
+(ert-deftest test-kibela-build-collection-from-note-templates ()
+  (let* ((expected `(,(propertize
+                       "日報"
+                       'template
+                       '(:title "日報 2000/01/01"
+                               :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
+                               :group-ids ("TestID1")
+                               :groups (((id "TestID1") (name "Home")))
+                               :folders ()))
+                     ,(propertize
+                       "定例 MTG"
+                       'template
+                       '(:title "定例 MTG 2000/01/01"
+                               :content "# 参加者\n\n - (参加者名) # アジェンダ\n\n- \n\n# \n\n- [ ] \n\n# 前回の宿題\n\n- [ ] \n\n# 議題\n\n# 宿題\n\n"
+                               :group-ids ("TestID1")
+                               :groups (((id "TestID1") (name "Home")))
+                               :folders (((id "FolderID1") (folderName "議事録/定例 MTG") (groups ((id "TestID1") (name "Home"))) (groupId "Home")))))))
+         (template1 '((name . "日報")
+                      (evaluatedTitle . "日報 2000/01/01")
+                      (content . "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n")
+                      (group-ids . ("TestID1"))
+                      (groups . (((id "TestID1") (name "Home"))))
+                      (folders . ())))
+         (template2 '((name . "定例 MTG")
+                      (evaluatedTitle . "定例 MTG 2000/01/01")
+                      (content . "# 参加者\n\n - (参加者名) # アジェンダ\n\n- \n\n# \n\n- [ ] \n\n# 前回の宿題\n\n- [ ] \n\n# 議題\n\n# 宿題\n\n")
+                      (group-ids . ("TestID1"))
+                      (groups . (((id "TestID1") (name "Home"))))
+                      (folders . (((id "FolderID1")
+                                  (evaluatedFullName "議事録/定例 MTG")
+                                  (groups ((id "TestID1")
+                                           (name "Home"))))))))
+         (templates `(,template1 ,template2))
+         (actual (kibela-build-collection-from-note-templates templates)))
+    (should (seq-set-equal-p expected actual
+                             (lambda (elt1 elt2)
+                               (let* ((template1 (get-text-property 0 'template elt1))
+                                      (title1 (plist-get template1 :title))
+                                      (template2 (get-text-property 0 'template elt2))
+                                      (title2 (plist-get template2 :title)))
+                                 (and (string-equal elt1 elt2)
+                                      (string-equal title1 title2))))))))
+
 (ert-deftest test-kibela-select-note-template-action ()
   "選択した文字列から template property を取得して
 kibela--new-note-from-template に渡すことを確認する."

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -136,3 +136,28 @@ kibela--new-note-from-template に渡すことを確認する."
                                              (should (string-equal "日報 2000/01/01"
                                                                    (plist-get template :title)))))
       (kibela-select-note-template-action selected))))
+
+(ert-deftest test-kibela--new-note-from-template ()
+  (let* ((template '(:title "日報 2000/01/01"
+                            :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
+                            :group-ids '("TestID1" "TestID2")
+                            :groups (((id . "TestID1") (name . "Home"))
+                                     ((id . "TestID2") (name . "Private")))
+                            :folders (((id . "FolderID1")
+                                       (folderName . "Folder 1")
+                                       (group . ((id . "TestID1")
+                                                  (name . "Home")))
+                                       (groupId . "Home"))
+                                      ((id . "FolderID2")
+                                       (folderName . "Folder 2")
+                                       (group . ((id . "TestID2")
+                                                  (name . "Private")))
+                                       (groupId . "Private"))))))
+      (with-temp-buffer
+        (kibela--new-note-from-template template)
+        (should (string-equal (buffer-name) "*Kibela* newnote"))
+        (should (string-equal header-line-format "Home > Folder 1 | Private > Folder 2"))
+        (should (string-equal (buffer-substring-no-properties (point-min) (point-max))
+                              "# 日報 2000/01/01\n\n# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"))
+        (kill-buffer) ;; FIXME: expect always executed but its only execute on success
+        )))

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -75,3 +75,21 @@
         (should (string-equal header-line-format "Fetched Test group"))
         (should (string-equal (buffer-substring-no-properties (point-min) (point-max)) "# Test note\n\n"))
         (kill-buffer)))))
+
+;;; template tests
+
+(ert-deftest test-kibela-select-note-template-action ()
+  "選択した文字列から template property を取得して
+kibela--new-note-from-template に渡すことを確認する."
+  (let* ((selected-template '(:title "日報 2000/01/01"
+                                     :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
+                                     :group-ids '("TestID1" "TestID2")
+                                     :groups '(((id "TestID1") (name "Home"))
+                                               ((id "TestID2") (name "Private")))
+                                     :folders '(((id "FolderID1") (folderName "Folder 1") (groups ((id "TestID1") (name "Home"))) (groupId "Home"))
+                                                ((id "FolderID2") (folderName "Folder 2") (groups ((id "TestID2") (name "Home"))) (groupId "Private")))))
+         (selected (propertize "日報" 'template selected-template)))
+    (noflet ((kibela--new-note-from-template (template)
+                                             (should (string-equal "日報 2000/01/01"
+                                                                   (plist-get template :title)))))
+      (kibela-select-note-template-action selected))))

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -161,3 +161,32 @@ kibela--new-note-from-template に渡すことを確認する."
                               "# 日報 2000/01/01\n\n# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"))
         (kill-buffer) ;; FIXME: expect always executed but its only execute on success
         )))
+
+(ert-deftest test-kibela-note-new-from-template ()
+  (let* ((response '((data (noteTemplates (edges . [((node
+                                                      (id . "TestId1")
+                                                      (name . "foo")
+                                                      (title . "Foo title")
+                                                      (evaluatedTitle . "Foo title")
+                                                      (content . "")
+                                                      (groups . [((id . "GroupId")
+                                                                  (name . "Home"))])
+                                                      (folders . [])))
+                                                    ((node
+                                                      (id . "TestId2")
+                                                      (name . "bar")
+                                                      (title . "Bar title")
+                                                      (evaluatedTitle . "Bar title")
+                                                      (content . "")
+                                                      (groups . [((id . "GroupId")
+                                                                  (name . "Home"))])
+                                                      (folders . [])))]))))))
+    (kibela-test--use-response-stub response
+      (with-temp-buffer
+        (with-simulated-input "foo RET" (kibela-note-new-from-template))
+        (should (string-equal (buffer-name) "*Kibela* newnote"))
+        (should (string-equal header-line-format "Home"))
+        (should (string-equal (buffer-substring-no-properties (point-min) (point-max))
+                              "# Foo title\n\n"))
+        (kill-buffer) ;; FIXME: expect always executed but its only execute on success
+        ))))

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -1,6 +1,7 @@
 (require 'kibela)
 (require 'ert)
 (require 'noflet)
+(require 'ert-x)
 
 (defmacro kibela-test--use-response-stub (response &rest body)
   (declare (indent defun))
@@ -180,13 +181,15 @@ kibela--new-note-from-template に渡すことを確認する."
                                                       (content . "")
                                                       (groups . [((id . "GroupId")
                                                                   (name . "Home"))])
-                                                      (folders . [])))]))))))
+                                                      (folders . [])))])))))
+         (completing-read-function #'completing-read-default))
     (kibela-test--use-response-stub response
       (with-temp-buffer
-        (with-simulated-input "foo RET" (kibela-note-new-from-template))
-        (should (string-equal (buffer-name) "*Kibela* newnote"))
-        (should (string-equal header-line-format "Home"))
-        (should (string-equal (buffer-substring-no-properties (point-min) (point-max))
-                              "# Foo title\n\n"))
+        (ert-simulate-keys (kbd "ba TAB RET")
+          (kibela-note-new-from-template)
+          (should (string-equal (buffer-name) "*Kibela* newnote"))
+          (should (string-equal header-line-format "Home"))
+          (should (string-equal (buffer-substring-no-properties (point-min) (point-max))
+                                "# Bar title\n\n")))
         (kill-buffer) ;; FIXME: expect always executed but its only execute on success
         ))))

--- a/kibela.el
+++ b/kibela.el
@@ -214,7 +214,10 @@ SELECTED は選択した記事テンプレート."
                         (let* ((response-data (assq 'data (graphql-simplify-response-edges data)))
                                (note-templates (assoc-default 'noteTemplates response-data))
                                (collection (kibela-build-collection-from-note-templates note-templates))
-                               (selected (completing-read "Note templates: " collection)))
+                               (selected-key (completing-read "Note templates: " collection))
+                               (selected (seq-find (lambda (elt)
+                                                     (string-equal elt selected-key))
+                                                   collection)))
                           (kibela-select-note-template-action selected)))))))
 
 ;;;###autoload


### PR DESCRIPTION
これでテンプレートから記事作成バッファを表示する部分の自動テストができるようになった

またテストを書いてる時に completing-read では property が抜け落ちるっぽいことに気付いたので
その部分の処理を書き直している