### PR TITLE
Separate show and edit

### DIFF
--- a/kibela-markdown-mode.el
+++ b/kibela-markdown-mode.el
@@ -36,17 +36,46 @@
       (kibela-note-update)
     (kibela-note-create)))
 
+(defun kibela-markdown--show-to-edit ()
+  (interactive)
+  (let ((base kibela-note-base))
+    (kibela-markdown-mode)
+    (setq kibela-note-base base)))
+
+(defun kibela-markdown--kill-edit-buffer ()
+  (interactive)
+  (if kibela-note-base
+      (let ((base kibela-note-base))
+        (erase-buffer)
+        (insert (concat "# " (assoc-default "title" base) "\n\n" (assoc-default "content" base)))
+        (kibela-markdown-view-mode))
+    (kill-current-buffer)))
+
 (defvar kibela-markdown-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map markdown-mode-map)
     (define-key map (kbd "C-c C-c C-c") 'kibela-markdown-post)
+    (define-key map (kbd "C-c C-z") 'kibela-markdown--kill-edit-buffer)
     map)
   "Keymap for `kibela-markdown-mode'.
-See also `markdown-mode-map'.")
+See also `gfm-mode-map'.")
 
 (define-derived-mode kibela-markdown-mode gfm-mode "Kibela Markdown"
   "Major mode for editing Kibela Markdown files."
   (use-local-map kibela-markdown-mode-map))
+
+(defvar kibela-markdown-view-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map markdown-mode-map)
+    (define-key map (kbd "C-c C-e") 'kibela-markdown--show-to-edit)
+    (define-key map (kbd "C-c C-z") 'kill-current-buffer)
+    map)
+  "Keymap for `kibela-markdown-view-mode'.
+See also `gfm-view-mode-map'.")
+
+(define-derived-mode kibela-markdown-view-mode gfm-view-mode "Kibela Markdown View"
+  "Major mode for viewing Kibela Markdown files."
+  (use-local-map kibela-markdown-view-mode-map))
 
 (provide 'kibela-markdown-mode)
 ;;; kibela-markdown-mode.el ends here

--- a/kibela-test.el
+++ b/kibela-test.el
@@ -200,7 +200,7 @@ kibela--new-note-from-template に渡すことを確認する."
         (kill-buffer) ;; FIXME: expect always executed but its only execute on success
         ))))
 
-;; edit
+;; show
 
 (ert-deftest test-kibela-note-show ()
   (let* ((response '((data
@@ -217,7 +217,7 @@ kibela--new-note-from-template に渡すことを確認する."
     (kibela-test--use-response-stub response
       (with-temp-buffer
         (kibela-note-show "NoteID")
-        (should (string-equal major-mode "kibela-markdown-mode"))
+        (should (string-equal major-mode "kibela-markdown-view-mode"))
         (should (string-equal (buffer-name) "*Kibela* NoteID"))
         (should (string-equal (buffer-substring-no-properties (point-min) (point-max))
                               "# posted note\n\nposted content"))

--- a/kibela.el
+++ b/kibela.el
@@ -361,7 +361,7 @@ URL などからではなく GraphQL で取得すること."
                                (buffer (get-buffer-create (concat "*Kibela* " id))))
                           (switch-to-buffer buffer)
                           (insert (concat "# " title "\n\n" content))
-                          (kibela-markdown-mode)
+                          (kibela-markdown-view-mode)
                           (setq header-line-format
                                 (kibela--build-header-line groups folders))
                           (setq kibela-note-base


### PR DESCRIPTION
これまでは編集画面で記事の閲覧も行うようにしていたが

- 自分が編集できない記事もある
- markdown-mode の閲覧用の見た目が良い

ということでとりあえず show と edit を分離した。

edit に移動するのは show の中で `C-c C-e` を叩く必要がある。

なお現時点では編集できない記事も edit に遷移できてしまうので
後でそれは直す