### PR TITLE
feat: Add kibela-markdown-open-in-browser

### DIFF
--- a/kibela-markdown-mode.el
+++ b/kibela-markdown-mode.el
@@ -38,18 +38,27 @@
 
 (defun kibela-markdown--show-to-edit ()
   (interactive)
-  (let* ((base kibela-note-base))
+  (let* ((base kibela-note-base)
+         (url kibela-note-url))
     (cond
      (kibela-note-can-be-updated
       (kibela-markdown-mode)
-      (setq kibela-note-base base))
+      (setq kibela-note-base base)
+      (setq kibela-note-url url))
      (t
       (message "cannot edit this note.")))))
+
+(defun kibela-markdown-open-in-browser ()
+  (interactive)
+  (if kibela-note-url
+      (browse-url kibela-note-url)
+    (message "URL is not exists")))
 
 (defun kibela-markdown--kill-edit-buffer ()
   (interactive)
   (if kibela-note-base
-      (let ((base kibela-note-base))
+      (let ((base kibela-note-base)
+            (url kibela-note-url))
         (erase-buffer)
         (insert (concat "# " (assoc-default "title" base) "\n\n" (assoc-default "content" base)))
         (kibela-markdown-view-mode)
@@ -61,6 +70,7 @@
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map gfm-mode-map)
     (define-key map (kbd "C-c C-c C-c") 'kibela-markdown-post)
+    (define-key map (kbd "C-c C-c C-o") 'kibela-markdown-open-in-browser)
     (define-key map (kbd "C-c C-z") 'kibela-markdown--kill-edit-buffer)
     map)
   "Keymap for `kibela-markdown-mode'.
@@ -73,6 +83,7 @@ See also `gfm-mode-map'.")
 (defvar kibela-markdown-view-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map gfm-view-mode-map)
+    (define-key map (kbd "C-c C-c C-o") 'kibela-markdown-open-in-browser)
     (define-key map (kbd "C-c C-e") 'kibela-markdown--show-to-edit)
     (define-key map (kbd "C-c C-z") 'kill-current-buffer)
     map)

--- a/kibela-markdown-mode.el
+++ b/kibela-markdown-mode.el
@@ -52,7 +52,9 @@
       (let ((base kibela-note-base))
         (erase-buffer)
         (insert (concat "# " (assoc-default "title" base) "\n\n" (assoc-default "content" base)))
-        (kibela-markdown-view-mode))
+        (kibela-markdown-view-mode)
+        (setq kibela-note-base base)
+        (setq kibela-note-can-be-updated t))
     (kill-current-buffer)))
 
 (defvar kibela-markdown-mode-map

--- a/kibela-markdown-mode.el
+++ b/kibela-markdown-mode.el
@@ -57,7 +57,7 @@
 
 (defvar kibela-markdown-mode-map
   (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map markdown-mode-map)
+    (set-keymap-parent map gfm-mode-map)
     (define-key map (kbd "C-c C-c C-c") 'kibela-markdown-post)
     (define-key map (kbd "C-c C-z") 'kibela-markdown--kill-edit-buffer)
     map)
@@ -70,7 +70,7 @@ See also `gfm-mode-map'.")
 
 (defvar kibela-markdown-view-mode-map
   (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map markdown-mode-map)
+    (set-keymap-parent map gfm-view-mode-map)
     (define-key map (kbd "C-c C-e") 'kibela-markdown--show-to-edit)
     (define-key map (kbd "C-c C-z") 'kill-current-buffer)
     map)

--- a/kibela.el
+++ b/kibela.el
@@ -57,6 +57,9 @@
 (defvar-local kibela-note-can-be-updated nil
   "記事が編集可能かどうかを保存する変数.")
 
+(defvar-local kibela-note-url nil
+  "記事 URL を保存する変数.")
+
 (defconst kibela-graphql-query-note
   (graphql-query
    (:arguments (($id . ID!))
@@ -66,6 +69,7 @@
                 content
                 coediting
                 canBeUpdated
+                url
                 (groups id name)
                 (folders
                  :arguments((first . 100))
@@ -349,6 +353,7 @@ URL などからではなく GraphQL で取得すること."
                                (content (assoc-default 'content note))
                                (coediting (assoc-default 'coediting note))
                                (can-be-updated (eq t (assoc-default 'canBeUpdated note)))
+                               (url (assoc-default 'url note))
                                (groups (assoc-default 'groups note))
                                (group-ids (mapcar (lambda (group) (assoc-default 'id group)) groups))
                                (row-folders (assoc-default 'folders note))
@@ -370,6 +375,7 @@ URL などからではなく GraphQL で取得すること."
                           (setq header-line-format
                                 (kibela--build-header-line groups folders))
                           (setq kibela-note-can-be-updated can-be-updated)
+                          (setq kibela-note-url url)
                           (setq kibela-note-base
                                 `(("title" . ,title)
                                   ("content" . ,content)


### PR DESCRIPTION
記事をブラウザで開く機能を追加した。
これがあると kibela.el に機能が足りなくても
ブラウザを使うということができるので便利

ついでに
edit から show へ戻る時に値を渡し忘れていた不具合も直している