### PR TITLE
fix: Respect coediting flag on create from template

### DIFF
--- a/kibela.el
+++ b/kibela.el
@@ -320,6 +320,10 @@ NOTE-TEMPLATES は Kibela に登録されている記事テンプレートの配
             (let* ((name (assoc-default 'name note-template))
                    (title (assoc-default 'evaluatedTitle note-template))
                    (content (assoc-default 'content note-template))
+                   (original-coediting (assoc-default 'coediting note-template))
+                   (coediting (if (or (null original-coediting) (eq original-coediting json-false))
+                                  nil
+                                t))
                    (groups (assoc-default 'groups note-template))
                    (group-ids (mapcar (lambda (group) (assoc-default 'id group)) groups))
                    (row-folders (assoc-default 'folders note-template))
@@ -329,7 +333,12 @@ NOTE-TEMPLATES は Kibela に登録されている記事テンプレートの配
                                              (group-id (assoc-default 'id group)))
                                         `((groupId . ,group-id) (group . ,group) (folderName . ,folder-name))))
                                     row-folders))
-                   (template `(:title ,title :content ,content :group-ids ,group-ids :groups ,groups :folders ,folders)))
+                   (template `(:title ,title
+                                      :content ,content
+                                      :coediting ,coediting
+                                      :group-ids ,group-ids
+                                      :groups ,groups
+                                      :folders ,folders)))
               (propertize name 'template template)))
           note-templates))
 

--- a/kibela.el
+++ b/kibela.el
@@ -661,8 +661,13 @@ TEMPLATE は記事作成時に利用するテンプレート."
          (buffer-content (substring-no-properties (buffer-string)))
          (title (substring-no-properties (cl-first (split-string buffer-content "\n")) 2))
          (content (string-join (cddr (split-string buffer-content "\n")) "\n"))
-         (coediting t) ;; TODO handle coediting
-         (draft json-false) ;; TODO handle draft
+         (coediting (if kibela-note-template
+                        (if (plist-get kibela-note-template :coediting) t
+                          json-false)
+                      t))
+         (draft (if kibela-note-template
+                    (plist-get kibela-note-template :draft)
+                  json-false))
          (group-ids (if kibela-note-template
                         (plist-get kibela-note-template :group-ids)
                       `(,(assoc-default 'id kibela-default-group))))
@@ -695,8 +700,7 @@ TEMPLATE は記事作成時に利用するテンプレート."
                                         (buffer (get-buffer-create "*Kibela* newnote")))
                                    (kill-buffer buffer)
                                    (setq kibela-note-template nil)
-                                   (message (concat "create note '" title "' has succeed.")))))))))
-    t))
+                                   (message (concat "create note '" title "' has succeed.")))))))))))
 
 ;;;###autoload
 (defun kibela-note-show (id)

--- a/test/kibela-test.el
+++ b/test/kibela-test.el
@@ -284,27 +284,31 @@
                        "日報"
                        'template
                        '(:title "日報 2000/01/01"
-                               :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
-                               :group-ids ("TestID1")
-                               :groups (((id "TestID1") (name "Home")))
-                               :folders ()))
+                                :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
+                                :coeding nil
+                                :group-ids ("TestID1")
+                                :groups (((id "TestID1") (name "Home")))
+                                :folders ()))
                      ,(propertize
                        "定例 MTG"
                        'template
                        '(:title "定例 MTG 2000/01/01"
-                               :content "# 参加者\n\n - (参加者名) # アジェンダ\n\n- \n\n# \n\n- [ ] \n\n# 前回の宿題\n\n- [ ] \n\n# 議題\n\n# 宿題\n\n"
-                               :group-ids ("TestID1")
-                               :groups (((id "TestID1") (name "Home")))
-                               :folders (((id "FolderID1") (folderName "議事録/定例 MTG") (groups ((id "TestID1") (name "Home"))) (groupId "Home")))))))
+                                :content "# 参加者\n\n - (参加者名) # アジェンダ\n\n- \n\n# \n\n- [ ] \n\n# 前回の宿題\n\n- [ ] \n\n# 議題\n\n# 宿題\n\n"
+                                :coeding t
+                                :group-ids ("TestID1")
+                                :groups (((id "TestID1") (name "Home")))
+                                :folders (((id "FolderID1") (folderName "議事録/定例 MTG") (groups ((id "TestID1") (name "Home"))) (groupId "Home")))))))
          (template1 '((name . "日報")
                       (evaluatedTitle . "日報 2000/01/01")
                       (content . "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n")
+                      (coeding . nil)
                       (group-ids . ("TestID1"))
                       (groups . (((id "TestID1") (name "Home"))))
                       (folders . ())))
          (template2 '((name . "定例 MTG")
                       (evaluatedTitle . "定例 MTG 2000/01/01")
                       (content . "# 参加者\n\n - (参加者名) # アジェンダ\n\n- \n\n# \n\n- [ ] \n\n# 前回の宿題\n\n- [ ] \n\n# 議題\n\n# 宿題\n\n")
+                      (coeding . t)
                       (group-ids . ("TestID1"))
                       (groups . (((id "TestID1") (name "Home"))))
                       (folders . (((id "FolderID1")
@@ -320,13 +324,25 @@
                                       (template2 (get-text-property 0 'template elt2))
                                       (title2 (plist-get template2 :title)))
                                  (and (string-equal elt1 elt2)
-                                      (string-equal title1 title2))))))))
+                                      (string-equal title1 title2)
+                                      (string-equal (plist-get template1 :content)
+                                                    (plist-get template2 :content))
+                                      ;; (equal (plist-get template1 :group-ids)
+                                      ;;        (plist-get template2 :group-ids))
+                                      ;; (equal (plist-get template1 :groups)
+                                      ;;        (plist-get template2 :groups))
+                                      ;; (equal (plist-get template1 :folders)
+                                      ;;        (plist-get template2 :folders))
+                                      (equal (plist-get template1 :coediting)
+                                             (plist-get template2 :coediting))
+                                      )))))))
 
 (ert-deftest test-kibela-select-note-template-action ()
   "選択した文字列から template property を取得して
 kibela--new-note-from-template に渡すことを確認する."
   (let* ((selected-template '(:title "日報 2000/01/01"
                                      :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
+                                     :coediting nil
                                      :group-ids '("TestID1" "TestID2")
                                      :groups '(((id "TestID1") (name "Home"))
                                                ((id "TestID2") (name "Private")))

--- a/test/kibela-test.el
+++ b/test/kibela-test.el
@@ -399,6 +399,7 @@ kibela からのレスポンスを completing-read で絞り込んで
                                                (title . "Foo title")
                                                (evaluatedTitle . "Foo title")
                                                (content . "")
+                                               (coediting . json-false)
                                                (groups . [((id . "GroupId")
                                                            (name . "Home"))])
                                                (folders . [])))
@@ -408,6 +409,7 @@ kibela からのレスポンスを completing-read で絞り込んで
                                                (title . "Bar title")
                                                (evaluatedTitle . "Bar title")
                                                (content . "")
+                                               (coediting . t)
                                                (groups . [((id . "GroupId")
                                                            (name . "Home"))])
                                                (folders . [])))])))
@@ -420,7 +422,7 @@ kibela からのレスポンスを completing-read で絞り込んで
           (should (string-equal header-line-format "Home"))
           (should (string-equal (buffer-substring-no-properties (point-min) (point-max))
                                 "# Bar title\n\n")))
-        (kill-buffer) ;; FIXME: expect always executed but its only execute on success
+        (kill-matching-buffers "^\\*Kibela\\*" nil t) ;; FIXME: expect always executed but its only execute on success
         ))))
 
 ;; show

--- a/test/kibela-test.el
+++ b/test/kibela-test.el
@@ -356,12 +356,13 @@ kibela--new-note-from-template に渡すことを確認する."
       (kibela-select-note-template-action selected))))
 
 (ert-deftest test-kibela--new-note-from-template ()
-  "kibela-note-new-from-template の内部で実行される
-kibela--new-note-from-template の挙動を確認する.
-これは渡された template の内容を元に新規ノート用のバッファを作成する."
+  "kibela-note-new-from-template の内部で実行される kibela--new-note-from-template のテスト.
+この関数は渡された template の内容を元に新規ノート用のバッファを作成し
+kibela-note-template に渡された template の情報を格納する."
   (let* ((template '(:title "日報 2000/01/01"
                             :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
                             :group-ids '("TestID1" "TestID2")
+                            :coediting nil
                             :groups (((id . "TestID1") (name . "Home"))
                                      ((id . "TestID2") (name . "Private")))
                             :folders (((id . "FolderID1")
@@ -380,7 +381,10 @@ kibela--new-note-from-template の挙動を確認する.
         (should (string-equal header-line-format "Home > Folder 1 | Private > Folder 2"))
         (should (string-equal (buffer-substring-no-properties (point-min) (point-max))
                               "# 日報 2000/01/01\n\n# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"))
-        (kill-buffer) ;; FIXME: expect always executed but its only execute on success
+
+        (should (not (null (plist-member kibela-note-template :coediting))))
+        (should (equal (plist-get kibela-note-template :coediting) nil))
+        (kill-matching-buffers "^\\*Kibela\\*" nil t) ;; FIXME: expect always executed but its only execute on success
         )))
 
 (ert-deftest test-kibela-note-new-from-template ()

--- a/test/kibela-test.el
+++ b/test/kibela-test.el
@@ -449,7 +449,7 @@ kibela からのレスポンスを completing-read で絞り込んで
                               "# posted note\n\nposted content"))
         (should (string-equal header-line-format "Home > foo > bar"))
 
-        (kill-buffer)) ;; FIXME: expect always executed but its only execute on success
+        (kill-matching-buffers "^\\*Kibela\\*" nil t)) ;; FIXME: expect always executed but its only execute on success
       )))
 
 ;; create

--- a/test/kibela-test.el
+++ b/test/kibela-test.el
@@ -277,6 +277,9 @@
 ;;; template tests
 
 (ert-deftest test-kibela-build-collection-from-note-templates ()
+  "kibela-build-collection-from-note-templates が
+取得したテンプレート一覧からテンプレート名を抽出し
+その他の属性を property としてそこに詰めていることをテストしている"
   (let* ((expected `(,(propertize
                        "日報"
                        'template
@@ -336,6 +339,9 @@ kibela--new-note-from-template に渡すことを確認する."
       (kibela-select-note-template-action selected))))
 
 (ert-deftest test-kibela--new-note-from-template ()
+  "kibela-note-new-from-template の内部で実行される
+kibela--new-note-from-template の挙動を確認する.
+これは渡された template の内容を元に新規ノート用のバッファを作成する."
   (let* ((template '(:title "日報 2000/01/01"
                             :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
                             :group-ids '("TestID1" "TestID2")
@@ -361,6 +367,9 @@ kibela--new-note-from-template に渡すことを確認する."
         )))
 
 (ert-deftest test-kibela-note-new-from-template ()
+  "kibela-note-new-from-template を実行した際に
+kibela からのレスポンスを completing-read で絞り込んで
+そのテンプレートの情報を buffer にセットすることをテストしている"
   (let* ((kibela-team "dummy")
          (kibela-access-token "dummy")
          (response '(noteTemplates (edges . [((node

--- a/test/kibela-test.el
+++ b/test/kibela-test.el
@@ -342,7 +342,7 @@
 kibela--new-note-from-template に渡すことを確認する."
   (let* ((selected-template '(:title "日報 2000/01/01"
                                      :content "# DONE\n\n- [x] \n\n# DOING\n\n- [ ] \n\n# TODO\n\n- [ ] \n\n"
-                                     :coediting nil
+                                     :coediting t
                                      :group-ids '("TestID1" "TestID2")
                                      :groups '(((id "TestID1") (name "Home"))
                                                ((id "TestID2") (name "Private")))
@@ -351,7 +351,8 @@ kibela--new-note-from-template に渡すことを確認する."
          (selected (propertize "日報" 'template selected-template)))
     (noflet ((kibela--new-note-from-template (template)
                                              (should (string-equal "日報 2000/01/01"
-                                                                   (plist-get template :title)))))
+                                                                   (plist-get template :title)))
+                                             (should (equal t (plist-get template :coediting)))))
       (kibela-select-note-template-action selected))))
 
 (ert-deftest test-kibela--new-note-from-template ()


### PR DESCRIPTION
Kibela に登録されているテンプレートから記事を作る時には
テンプレートに含まれている coediting フラグを無視しないように修正しました。

これまでは coediting フラグを無視して固定で共同編集を有効にしていたので
日報のような共同編集させたくないような記事も共同編集が ON になってしまっていました