### PR TITLE
chore: Add .github/release.yml for release note auto generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Bug fixes 🐛
+      labels:
+        - Semver-Patch
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
リリースノートの作成を省力化するために
release.yml を追加した