### PR TITLE
chore: Add `require label` workflow

### DIFF
--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -1,0 +1,21 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: |
+            bug
+            maintenance
+            documentation
+            enhancement
+            breaking change


### PR DESCRIPTION
自動リリースノートの作成や
バージョンアップ PR の自動作成のために必須化した