### PR TITLE
chore: change tagging workflow trigger

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -3,8 +3,9 @@ name: tagging
 on:
   pull_request:
     branches:
-      - master
+      - 'bump-version-*'
     types: [closed]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
branches に master を指定するのは違っていたようなので修正。
また手動起動もできるように workflow_dispatch も追加