### PR TITLE
chore: remove if condition from tagging workflow

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -8,14 +8,12 @@ on:
 
 jobs:
   test:
-    if: contains( github.event.pull_request.labels.*.name, 'bump version')
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
   # copy from bump-version.yml
   # FIXME: reusing workflow か action として定義し直して再利用する
   detect-current-version:
-    if: contains( github.event.pull_request.labels.*.name, 'bump version')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.detect-current-version.outputs.version }}


### PR DESCRIPTION
マージするブランチで判定できるので
タグの有無で判定する必要はなかった