### PR TITLE
chore: fix tagging workflow

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -3,18 +3,22 @@ name: tagging
 on:
   pull_request:
     branches:
-      - 'bump-version-*'
+      - 'main'
     types: [closed]
   workflow_dispatch:
 
 jobs:
   test:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, "bump-version")
+
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
   # copy from bump-version.yml
   # FIXME: reusing workflow か action として定義し直して再利用する
   detect-current-version:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, "bump-version")
+
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.detect-current-version.outputs.version }}

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -80,3 +80,6 @@ jobs:
     uses: ./.github/workflows/create-release.yml
     with:
       tag: ${{ needs.tag.outputs.version }}
+    permissions:
+      contents: write
+      packages: write


### PR DESCRIPTION
tagging workflow に誤りがあったので修正

## 起動条件の修正

main に 'bump-version-*' ブランチの Pull Request がマージされた時だけ起動するように変更した

元々の記述もその想定だったけどそれだと動かないっぽい

## create-release workflow 呼び出しの修正

permissions も与える必要があった