### PR TITLE
Drop support Emacs 26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         emacs-version:
-          - 26.3
           - 27.2
           - 28.2
           - snapshot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - 'Eask'
       - '*.el'
       - 'test/*-test.el'
+      - '.github/workflows/test.yml'
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
- markdown-mode が 26 をサポートしていないこと
- 26 で CI がコケること

から Emacs 26 での CI を回さないようにしました。
Goodbye 26.3