### PR TITLE
ci: Accept "dependencies" label

### DIFF
--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -17,6 +17,7 @@ jobs:
             bug
             refactoring
             maintenance
+            dependencies
             documentation
             enhancement
             breaking change


### PR DESCRIPTION
https://github.com/mugijiru/emacs-kibela/pull/65
が label 不備でマージできなくなっているので修正