### PR TITLE
ci: Drop Emacs 27.2 support on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
           - 28.2
           - 29.1
           - snapshot
-
+        exclude:
+          - os: macos-latest
+            emacs-version: 27.2
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
CI 上で macOS 環境の Emacs 27.2 を取得できなくなったので
その環境でのテストをしないように変更