### PR TITLE
chore: Drop support Emacs 28.2<

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         emacs-version:
-          - 27.2
           - 28.2
           - 29.4
           - snapshot
-        exclude:
-          - os: macos-latest
-            emacs-version: 27.2
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         eask clean all
         eask install-deps --dev
         eask package
-        eask install --dev
+        eask install
         eask compile
         eask test ert-runner
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         emacs-version:
           - 27.2
           - 28.2
-          - 29.1
+          - 29.4
           - snapshot
         exclude:
           - os: macos-latest
@@ -60,7 +60,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.1
+        version: 29.4
 
     - uses: emacs-eask/setup-eask@master
       with:
@@ -100,7 +100,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.1
+        version: 29.4
 
     - uses: emacs-eask/setup-eask@master
       with:
@@ -119,7 +119,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.1
+        version: 29.4
 
     - uses: emacs-eask/setup-eask@master
       with:
@@ -138,7 +138,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.1
+        version: 29.4
 
     - uses: emacs-eask/setup-eask@master
       with:

--- a/Eask
+++ b/Eask
@@ -12,7 +12,7 @@
 (source "gnu")
 (source "melpa")
 
-(depends-on "emacs" "26.1")
+(depends-on "emacs" "28.2")
 (depends-on "graphql" "0.1.1")
 (depends-on "request" "0.3.3")
 (depends-on "markdown-mode" "2.5")

--- a/kibela.el
+++ b/kibela.el
@@ -6,7 +6,7 @@
 ;; Maintainer: mugijiru <106833+mugijiru@users.noreply.github.com>
 ;; URL: https://github.com/mugijiru/emacs-kibela
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1") (graphql "0.1.1") (request "0.3.3") (markdown-mode "2.5") (edit-indirect "0.1.10"))
+;; Package-Requires: ((emacs "28.2") (graphql "0.1.1") (request "0.3.3") (markdown-mode "2.5") (edit-indirect "0.1.10"))
 ;; Keywords: kibela, tools
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Emacs 28.2 より下は対応しない方針で CI などから取り除いた