### PR TITLE
chore: Ignore compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .eask
+*.elc
 dist
 tmp


### PR DESCRIPTION
compile されたファイルは Git 管理下には置かないので .gitignore に追加した