### PR TITLE
style: Silence compiler warnings for kibela-markdown-mode.el

### DIFF
--- a/kibela-markdown-mode.el
+++ b/kibela-markdown-mode.el
@@ -32,6 +32,12 @@
 (declare-function kibela-note-create "kibela")
 (declare-function kibela-note-update "kibela")
 
+(defvar kibela-note-base)
+(defvar kibela-note-groups)
+(defvar kibela-note-folders)
+(defvar kibela-note-url)
+(defvar kibela-note-can-be-updated)
+
 (defun kibela-markdown-post ()
   "Kibela に投稿する処理."
   (interactive)


### PR DESCRIPTION
kibela.el に定義されている変数を参照しているため
defvar を使うことでで compiler warning を黙らせた