### PR TITLE
ci: update Emacs version to 30.1 in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         emacs-version:
           - 28.2
           - 29.4
+          - 30.1
           - snapshot
     steps:
     - uses: actions/checkout@v4
@@ -56,7 +57,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.4
+        version: 30.1
 
     - uses: emacs-eask/setup-eask@master
       with:
@@ -96,7 +97,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.4
+        version: 30.1
 
     - uses: emacs-eask/setup-eask@master
       with:
@@ -115,7 +116,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.4
+        version: 30.1
 
     - uses: emacs-eask/setup-eask@master
       with:
@@ -134,7 +135,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.4
+        version: 30.1
 
     - uses: emacs-eask/setup-eask@master
       with:
@@ -153,7 +154,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: 29.4
+        version: 30.1
 
     - uses: emacs-eask/setup-eask@master
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.elc
 dist
 tmp
+.aider*


### PR DESCRIPTION
Update the Emacs version used in the CI workflow to 30.1.