### PR TITLE
chore(dependabot): add artifact grouping configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
       day: tuesday
       time: "09:00"
       timezone: Asia/Tokyo
+    groups:
+      artifacts:
+        patterns:
+          - "upload-artifact"
+          - "download-artifact"


### PR DESCRIPTION
# 概要

DependAbot構成ファイルにアーティファクトの新しいグループ構成を追加しました

# 変更理由

upload-artifact と download-artifact はペアになっていて
片方だけ上げるとうまく動かないため