### PR TITLE
chore: Use hash value for actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -88,7 +88,7 @@ jobs:
 
             fs.writeFileSync("${{ github.workspace }}/tags.txt", tags)
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3.2.1
         with:
           name: pr-${{matrix.pr_number}}-labels
           path: ${{ github.workspace }}/tags.txt
@@ -111,7 +111,7 @@ jobs:
         run: npm install -g semver
 
       - name: download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           path: matrix-tags
       - name: merge

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 18
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.detect-current-version.outputs.version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: detect current version
       id: detect-current-version
@@ -36,7 +36,7 @@ jobs:
       pull_request_numbers: ${{ steps.detect-prs.outputs.pull_request_numbers }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
 
@@ -188,7 +188,7 @@ jobs:
     if: ${{ needs.select-version.outputs.version != needs.detect-current-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: bump version
         run: |

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: detect labels
         id: detect-labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -196,7 +196,7 @@ jobs:
           sed -i -e "2s/${{ needs.detect-current-version.outputs.version }}/${{ needs.select-version.outputs.version }}/" Eask
           git add kibela.el Eask
 
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           title: Bump version from ${{ needs.detect-current-version.outputs.version }} to ${{ needs.select-version.outputs.version }}
           branch: bump-version-${{ needs.select-version.outputs.version }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Generate release note contents
         id: release_note
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const result = await github.rest.repos.generateReleaseNotes({
@@ -35,7 +35,7 @@ jobs:
             return result.data.body
 
       - name: Create release
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const result = await github.rest.repos.createRelease({

--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -24,7 +24,7 @@ jobs:
       version: ${{ steps.detect-current-version.outputs.version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: detect current version
       id: detect-current-version
@@ -49,7 +49,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # 要らないかも?
       - name: get latest tag

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -54,7 +54,7 @@ jobs:
       # 要らないかも?
       - name: get latest tag
         id: latest-tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const result = await github.rest.repos.getLatestRelease({

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - 30.1
           - snapshot
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: jcs090218/setup-emacs@master
       with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: jcs090218/setup-emacs@master
       with:
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: jcs090218/setup-emacs@master
       with:
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: jcs090218/setup-emacs@master
       with:
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: jcs090218/setup-emacs@master
       with:
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: jcs090218/setup-emacs@master
       with:


### PR DESCRIPTION
# 概要

GitHub Actions workflows で利用している各 action のバージョン指定を hash 値でするように変更した

# 変更の理由

セキュリティ上の理由で推奨されているため