### PR TITLE
feat(emacs): add directory local variables for emacs-lisp mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,6 @@
+;;; Directory Local Variables         -*- no-byte-compile: t; -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode . ((indent-tabs-mode . nil)
+                     (fill-column . 80)
+                     (elisp-lint-ignored-validators . ("package-lint")))))


### PR DESCRIPTION
# 概要

`.dir-locals.el`ファイルを追加し、
`emacs-lisp-mode` に関する設定を構成します

# 設定内容

- `indent-tabs-mode` の無効化
- `fill-column` を 80 に設定
- `package-lint` を `elisp-lint` で利用しないように設定
  - メインじゃないファイルでPackage-required を誤検知する為
  - なお `package-lint` は別途 CI でチェックしている