### PR TITLE
*** refactor(tests): enable lexical binding in test files

### DIFF
--- a/test/kibela-markdown-mode-test.el
+++ b/test/kibela-markdown-mode-test.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t; -*-
+
 (require 'kibela-markdown-mode)
 (require 'ert)
 (require 'ert-x)

--- a/test/kibela-test.el
+++ b/test/kibela-test.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t; -*-
+
 (require 'kibela)
 (require 'ert)
 (require 'ert-x)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,3 +1,5 @@
+;; -*- lexical-binding: t; -*-
+
 (when (require 'undercover nil t)
   (undercover "*.el"
               (:send-report nil)


### PR DESCRIPTION
Enable `lexical-binding` in the following test files:
+ `kibela-markdown-mode-test.el`
+ `kibela-test.el`
+ `test-helper.el`

This change improves performance
and ensures consistency across test files.