### PR TITLE
ci: Specify revision hash to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@35c7e05d593c6b5789155e9311ab2aea935fb690
       with:
         version: ${{ matrix.emacs-version }}
 
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@35c7e05d593c6b5789155e9311ab2aea935fb690
       with:
         version: 30.1
 
@@ -95,7 +95,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@35c7e05d593c6b5789155e9311ab2aea935fb690
       with:
         version: 30.1
 
@@ -114,7 +114,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@35c7e05d593c6b5789155e9311ab2aea935fb690
       with:
         version: 30.1
 
@@ -133,7 +133,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@35c7e05d593c6b5789155e9311ab2aea935fb690
       with:
         version: 30.1
 
@@ -152,7 +152,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@35c7e05d593c6b5789155e9311ab2aea935fb690
       with:
         version: 30.1
 
@@ -172,7 +172,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: jcs090218/setup-emacs@master
+    - uses: jcs090218/setup-emacs@35c7e05d593c6b5789155e9311ab2aea935fb690
       with:
         version: 30.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         version: ${{ matrix.emacs-version }}
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@6eb69769d8b3532d18a1b354f876bb2477081b7d
       with:
         version: 'snapshot'
 
@@ -59,7 +59,7 @@ jobs:
       with:
         version: 30.1
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@6eb69769d8b3532d18a1b354f876bb2477081b7d
       with:
         version: 'snapshot'
 
@@ -99,7 +99,7 @@ jobs:
       with:
         version: 30.1
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@6eb69769d8b3532d18a1b354f876bb2477081b7d
       with:
         version: 'snapshot'
 
@@ -118,7 +118,7 @@ jobs:
       with:
         version: 30.1
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@6eb69769d8b3532d18a1b354f876bb2477081b7d
       with:
         version: 'snapshot'
 
@@ -137,7 +137,7 @@ jobs:
       with:
         version: 30.1
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@6eb69769d8b3532d18a1b354f876bb2477081b7d
       with:
         version: 'snapshot'
 
@@ -156,7 +156,7 @@ jobs:
       with:
         version: 30.1
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@6eb69769d8b3532d18a1b354f876bb2477081b7d
       with:
         version: 'snapshot'
 
@@ -176,7 +176,7 @@ jobs:
       with:
         version: 30.1
 
-    - uses: emacs-eask/setup-eask@master
+    - uses: emacs-eask/setup-eask@6eb69769d8b3532d18a1b354f876bb2477081b7d
       with:
         version: 'snapshot'
 


### PR DESCRIPTION
setup-emacs, setup-eask のそれぞれに対し
master ではなく hash 値を指定するようにした。
変にバージョンが上がってセキュリティ的な不具合を埋めてしまわないようにするため