### PR TITLE
docs: Translate all Japanese descriptions to English

### DIFF
--- a/kibela.el
+++ b/kibela.el
@@ -50,8 +50,8 @@ Each element has the form (NAME TEAM ACCESS-TOKEN)."
   "Kibela access token for login.")
 
 (defvar-local kibela-note-base nil
-  "記事取得時の状態を保持する.
-記事更新時に利用する.")
+  "Holds the state of the note when it was retrieved.
+Used when updating the note.")
 
 (defvar-local kibela-note-template nil
   "使用する記事テンプレートを保持する.

--- a/kibela.el
+++ b/kibela.el
@@ -61,7 +61,7 @@ Used when creating a note from a template.")
   "Variable to store the default posting group.")
 
 (defvar-local kibela-note-can-be-updated nil
-  "記事が編集可能かどうかを保存する変数.")
+  "Variable to store whether the note can be updated.")
 
 (defvar-local kibela-note-id nil
   "記事 ID を保存する変数.")

--- a/kibela.el
+++ b/kibela.el
@@ -58,7 +58,7 @@ Used when updating the note.")
 Used when creating a note from a template.")
 
 (defvar kibela-default-group nil
-  "デフォルトの投稿先グループを保存する変数.")
+  "Variable to store the default posting group.")
 
 (defvar-local kibela-note-can-be-updated nil
   "記事が編集可能かどうかを保存する変数.")

--- a/kibela.el
+++ b/kibela.el
@@ -139,8 +139,8 @@ Used for pagination in the group's note list.")
       cursor
       (node
        (note id title content contentUpdatedAt coediting canBeUpdated url))))))
-  "最近見た Note を取得するためのクエリ.
-ページ送りで利用している")
+  "Query to retrieve recently viewed notes.
+Used for pagination.")
 
 (defconst kibela-graphql-query-recent-browsing-notes-next
   (graphql-query

--- a/kibela.el
+++ b/kibela.el
@@ -176,7 +176,7 @@ Used for pagination.")
 
 (defconst kibela-graphql-query-default-group
   (graphql-query ((defaultGroup id name)))
-  "デフォルトの投稿先グループを取得するためのクエリ.")
+  "Query to retrieve the default posting group.")
 
 (defconst kibela-graphql-query-note-templates
   (graphql-query

--- a/kibela.el
+++ b/kibela.el
@@ -90,7 +90,7 @@ Used to advance to the next page.")
   "Whether the next page exists in the note list.")
 
 (defvar-local kibela-has-prev-page nil
-  "記事一覧で前のページが存在するかどうか.")
+  "Whether the previous page exists in the note list.")
 
 (defconst kibela-graphql-query-group-notes-prev
   (graphql-query

--- a/kibela.el
+++ b/kibela.el
@@ -154,7 +154,7 @@ Used for pagination.")
       cursor
       (node
        (note id title content contentUpdatedAt coediting canBeUpdated url))))))
-  "最近見た Note を取得するためのクエリ.")
+  "Query to retrieve recently viewed notes.")
 
 (defconst kibela-graphql-query-note
   (graphql-query

--- a/kibela.el
+++ b/kibela.el
@@ -79,8 +79,8 @@ Used when creating a note from a template.")
   :type 'integer)
 
 (defvar-local kibela-first-cursor nil
-  "記事一覧で表示している中で先頭の記事の cursor を保存する.
-前ページに戻るために利用する.")
+  "Stores the cursor of the first note displayed in the note list.
+Used to return to the previous page.")
 
 (defvar-local kibela-last-cursor nil
   "記事一覧で表示している中で先頭の記事の cursor を保存する.

--- a/kibela.el
+++ b/kibela.el
@@ -598,8 +598,8 @@ DATA is the JSON from a successful request."
 
 (cl-defun
     kibela--like-success (&key _data &allow-other-keys)
-  "記事に Like をつけるリクエストが成功した時の処理.
-リクエストが成功したら中身を確認せず like したように表示を切り替える"
+  "Handler for successful like request.
+Updates display to show liked status without verifying response."
   (let ((groups kibela-note-groups)
         (folders kibela-note-folders))
     (setq header-line-format
@@ -610,7 +610,7 @@ DATA is the JSON from a successful request."
            :exist-note-p t))))
 
 (defun kibela-like ()
-  "記事に Like をつける処理."
+  "Add a like to the current note."
   (interactive "e")
   (let ((query kibela-graphql-mutation-like-note)
         (variables `((input . ((likableId . ,kibela-note-id))))))
@@ -618,8 +618,8 @@ DATA is the JSON from a successful request."
 
 (cl-defun
     kibela--unlike-success (&key _data &allow-other-keys)
-  "記事に Like を外すリクエストが成功した時の処理.
-リクエストが成功したら中身を確認せず like を外したように表示を切り替える"
+  "Handler for successful unlike request.
+Updates display to show unliked status without verifying response."
   (let ((groups kibela-note-groups)
         (folders kibela-note-folders))
     (setq header-line-format
@@ -630,7 +630,7 @@ DATA is the JSON from a successful request."
            :exist-note-p t))))
 
 (defun kibela-unlike ()
-  "記事の Like を外す処理."
+  "Remove a like from the current note."
   (interactive "e")
   (let ((query kibela-graphql-mutation-unlike-note)
         (variables `((input . ((likableId . ,kibela-note-id))))))

--- a/kibela.el
+++ b/kibela.el
@@ -198,14 +198,14 @@ Used for pagination.")
    (:arguments
     (($input . CreateNoteInput!))
     (createNote :arguments ((input . ($ input))) (note title content))))
-  "Note を作成するためのクエリ.")
+  "Query to create a note.")
 
 (defconst kibela-graphql-mutation-update-note
   (graphql-mutation
    (:arguments
     (($input . UpdateNoteInput!))
     (updateNote :arguments ((input . ($ input))) (note title content))))
-  "Note を更新するためのクエリ.")
+  "Query to update a note.")
 
 (defconst kibela-graphql-mutation-like-note
   (graphql-mutation

--- a/kibela.el
+++ b/kibela.el
@@ -214,7 +214,7 @@ Used for pagination.")
     (like
      :arguments ((input . ($ input)))
      (likers :arguments ((first . 100)) (totalCount) (edges (node id))))))
-  "Note をいいねするためのクエリ.")
+  "Query to like a note.")
 
 (defconst kibela-graphql-mutation-unlike-note
   (graphql-mutation
@@ -223,7 +223,7 @@ Used for pagination.")
     (unlike
      :arguments ((input . ($ input)))
      (likers :arguments ((first . 100)) (totalCount) (edges (node id))))))
-  "Note のいいねを取り消すためのクエリ.")
+  "Query to unlike a note.")
 
 (defun kibela-endpoint ()
   "API endpoint."

--- a/kibela.el
+++ b/kibela.el
@@ -651,15 +651,15 @@ Updates display to show unliked status without verifying response."
 (cl-defun
     kibela--build-header-line
     (groups &optional (folders '()) &key (liked-by-me-p nil) (exist-note-p nil))
-  "グループ/フォルダ情報から header-line 用の文字列を構築する.
-edit と new from template で利用している.
+  "Build header-line string from group/folder information.
+Used in edit and new-from-template modes.
 
-GROUPS はその記事が所属しているグループの一覧.
-FOLDERS はその記事が収められているフォルダの一覧.
-これら二つの値から header line を構築する.
+GROUPS is a list of groups the note belongs to.
+FOLDERS is a list of folders containing the note.
+These values are used to construct the header line.
 
-LIKED-BY-ME-P は自分がその記事を Like しているかどうか.
-EXIST-NOTE-P はその記事が存在するかどうか."
+LIKED-BY-ME-P indicates if the current user has liked the note.
+EXIST-NOTE-P indicates if the note actually exists."
   (let*
       ((groups-without-folder
         (seq-remove

--- a/kibela.el
+++ b/kibela.el
@@ -87,7 +87,7 @@ Used to return to the previous page.")
 Used to advance to the next page.")
 
 (defvar-local kibela-has-next-page nil
-  "記事一覧で次のページが存在するかどうか.")
+  "Whether the next page exists in the note list.")
 
 (defvar-local kibela-has-prev-page nil
   "記事一覧で前のページが存在するかどうか.")

--- a/kibela.el
+++ b/kibela.el
@@ -291,9 +291,9 @@ DATA is the JSON from the successful request."
       (kibela--request query nil #'kibela--store-default-group-success)))))
 
 (defun kibela-build-collection-from-note-templates (note-templates)
-  "記事テンプレート一覧から collection を生成する関数.
+  "Function to generate a collection from note templates.
 
-NOTE-TEMPLATES は Kibela に登録されている記事テンプレートの配列."
+NOTE-TEMPLATES is an array of note templates registered in Kibela."
   (mapcar
    (lambda (note-template)
      (let* ((name (assoc-default 'name note-template))

--- a/kibela.el
+++ b/kibela.el
@@ -340,7 +340,7 @@ SELECTED is the selected note template."
 
 ;;;###autoload
 (defun kibela-note-new-from-template ()
-  "記事テンプレートから選択したら新規作成用のバッファを表示するコマンド."
+  "Command to display a new note buffer from a selected template."
   (interactive)
   (unless (and kibela-team kibela-access-token)
     (kibela-switch-team))

--- a/kibela.el
+++ b/kibela.el
@@ -67,7 +67,7 @@ Used when creating a note from a template.")
   "Variable to store the note ID.")
 
 (defvar-local kibela-note-url nil
-  "記事 URL を保存する変数.")
+  "Variable to store the note URL.")
 
 (defvar-local kibela-note-groups nil)
 (defvar-local kibela-note-folders nil)

--- a/kibela.el
+++ b/kibela.el
@@ -83,8 +83,8 @@ Used when creating a note from a template.")
 Used to return to the previous page.")
 
 (defvar-local kibela-last-cursor nil
-  "記事一覧で表示している中で先頭の記事の cursor を保存する.
-前ページに戻るために利用する.")
+  "Stores the cursor of the last note displayed in the note list.
+Used to advance to the next page.")
 
 (defvar-local kibela-has-next-page nil
   "記事一覧で次のページが存在するかどうか.")

--- a/kibela.el
+++ b/kibela.el
@@ -274,9 +274,9 @@ SUCCESS is the handler for when the request succeeds."
 
 (cl-defun
     kibela--store-default-group-success (&key data &allow-other-keys)
-  "デフォルトグループ取得リクエスト成功後のデータ格納処理.
+  "Data storage process after successful default group fetch request.
 
-DATA はリクエスト成功時の JSON."
+DATA is the JSON from the successful request."
   (let* ((response-data (assoc-default 'data data))
          (group (assoc-default 'defaultGroup response-data)))
     (setq kibela-default-group group)))

--- a/kibela.el
+++ b/kibela.el
@@ -797,7 +797,7 @@ TEMPLATE is the note template to use for creation."
 (defun kibela-note-show (id)
   "Display a note.
 
-ID is the note's identifier. 
+ID is the note's identifier.
 Note that GraphQL uses encoded string IDs rather than numeric ones,
 so IDs should be obtained through GraphQL queries rather than from URLs."
   (unless (and kibela-team kibela-access-token)

--- a/kibela.el
+++ b/kibela.el
@@ -282,7 +282,7 @@ DATA is the JSON from the successful request."
     (setq kibela-default-group group)))
 
 (defun kibela-store-default-group ()
-  "デフォルトの投稿先グループを取得する."
+  "Fetch the default posting group."
   (cond
    (kibela-default-group
     nil)

--- a/kibela.el
+++ b/kibela.el
@@ -125,7 +125,7 @@ Used for pagination in the group's note list.")
       (edges
        cursor
        (node id title content contentUpdatedAt coediting canBeUpdated url))))))
-  "グループ配下の Note を取得するためのクエリ.")
+  "Query to retrieve notes within a group.")
 
 (defconst kibela-graphql-query-recent-browsing-notes-prev
   (graphql-query

--- a/kibela.el
+++ b/kibela.el
@@ -331,9 +331,9 @@ NOTE-TEMPLATES is an array of note templates registered in Kibela."
    note-templates))
 
 (defun kibela-select-note-template-action (selected)
-  "記事テンプレート選択時の処理.
+  "Handler for note template selection.
 
-SELECTED は選択した記事テンプレート."
+SELECTED is the selected note template."
   (let ((template (get-text-property 0 'template selected)))
     (if template
         (kibela--new-note-from-template template))))

--- a/kibela.el
+++ b/kibela.el
@@ -488,9 +488,9 @@ MARKER contains the cursor position in the note list."
 
 (cl-defun
     kibela--recent-browsing-notes-success (&key data &allow-other-keys)
-  "最近見た Notes を取得する処理.
+  "Process to fetch recently viewed notes.
 
-DATA はリクエスト成功時の JSON."
+DATA is the JSON from a successful request."
   (let* ((row-data (assoc-default 'data data))
          (row-note-browsing-histories
           (assoc-default 'noteBrowsingHistories row-data))
@@ -532,14 +532,14 @@ DATA はリクエスト成功時の JSON."
     (tabulated-list-print)))
 
 (defun kibela-recent-browsing-notes-refresh ()
-  "最近見た記事一覧を読み込み直す処理."
+  "Process to reload the list of recently viewed notes."
   (message "Fetch recent browsing notes...")
   (let* ((query kibela-graphql-query-recent-browsing-notes-next)
          (variables `((perPage . ,kibela-per-page))))
     (kibela--request query variables #'kibela--recent-browsing-notes-success)))
 
 (defun kibela-recent-browsing-notes-next-page ()
-  "記事一覧で次のページを取得する処理."
+  "Process to fetch the next page of recently viewed notes."
   (interactive)
   (cond
    (kibela-has-next-page
@@ -552,7 +552,7 @@ DATA はリクエスト成功時の JSON."
     (message "Current page is last"))))
 
 (defun kibela-recent-browsing-notes-prev-page ()
-  "記事一覧で前のページを取得する処理."
+  "Process to fetch the previous page of recently viewed notes."
   (interactive)
   (cond
    (kibela-has-prev-page
@@ -795,11 +795,11 @@ TEMPLATE は記事作成時に利用するテンプレート."
 
 ;;;###autoload
 (defun kibela-note-show (id)
-  "記事表示.
+  "Display a note.
 
-ID は記事の id.
-GraphQL で扱う ID は数字ではなく何らかの変換をされた文字列のようなので
-URL などからではなく GraphQL で取得すること."
+ID is the note's identifier. 
+Note that GraphQL uses encoded string IDs rather than numeric ones,
+so IDs should be obtained through GraphQL queries rather than from URLs."
   (unless (and kibela-team kibela-access-token)
     (kibela-switch-team))
   (let ((query kibela-graphql-query-note)

--- a/kibela.el
+++ b/kibela.el
@@ -38,8 +38,8 @@
 (defvar tabulated-list-sort-key)
 
 (defcustom kibela-auth-list nil
-  "Kibela の認証情報.
-Each element has the form (NAME TEAM ACCESS-TOKEN)"
+  "Authentication information for Kibela.
+Each element has the form (NAME TEAM ACCESS-TOKEN)."
   :group 'kibela
   :type '(alist :value-type (string string string)))
 

--- a/kibela.el
+++ b/kibela.el
@@ -54,8 +54,8 @@ Each element has the form (NAME TEAM ACCESS-TOKEN)."
 Used when updating the note.")
 
 (defvar-local kibela-note-template nil
-  "使用する記事テンプレートを保持する.
-テンプレートから記事を作成する時に利用する.")
+  "Holds the note template to be used.
+Used when creating a note from a template.")
 
 (defvar kibela-default-group nil
   "デフォルトの投稿先グループを保存する変数.")

--- a/kibela.el
+++ b/kibela.el
@@ -468,8 +468,8 @@ MARKER contains the cursor position in the note list."
 
 ;;;###autoload
 (defun kibela-group-notes ()
-  "記事一覧を開くコマンド.
-現在はデフォルトグループの記事一覧のみ開けるようになっている."
+  "Open a list of notes.
+Currently only shows notes from the default group."
   (interactive)
   (unless (and kibela-team kibela-access-token)
     (kibela-switch-team))
@@ -704,9 +704,9 @@ EXIST-NOTE-P indicates if the note actually exists."
 
 ;;;###autoload
 (defun kibela-note-new (title)
-  "記事を作成するバッファを用意する.
+  "Prepare a buffer for creating a new note.
 
-TITLE は新しく作成する記事のタイトル."
+TITLE is the title of the new note to create."
   (interactive "stitle: ")
   (unless (and kibela-team kibela-access-token)
     (kibela-switch-team))
@@ -720,9 +720,9 @@ TITLE は新しく作成する記事のタイトル."
     t))
 
 (defun kibela--new-note-from-template (template)
-  "記事を作成するバッファを用意する.
+  "Prepare a buffer for creating a note from a template.
 
-TEMPLATE は記事作成時に利用するテンプレート."
+TEMPLATE is the note template to use for creation."
   (let* ((title (plist-get template :title))
          (content (plist-get template :content))
          (groups (plist-get template :groups))
@@ -862,7 +862,7 @@ so IDs should be obtained through GraphQL queries rather than from URLs."
     t))
 
 (defun kibela-note-update ()
-  "記事更新."
+  "Update the current note."
   (interactive)
   (let* ((query kibela-graphql-mutation-update-note)
          (id (cl-second (split-string (buffer-name))))

--- a/kibela.el
+++ b/kibela.el
@@ -74,7 +74,7 @@ Used when creating a note from a template.")
 (defvar-local kibela-note-liked-by-me nil)
 
 (defcustom kibela-per-page 40
-  "記事一覧など、複数件のデータを取得する時の最大値."
+  "Maximum number of items to retrieve at once, such as in a list of notes."
   :group 'kibela
   :type 'integer)
 

--- a/kibela.el
+++ b/kibela.el
@@ -363,9 +363,9 @@ SELECTED is the selected note template."
 
 (cl-defun
     kibela--group-notes-success (&key data &allow-other-keys)
-  "グループとその配下の Notes を取得する処理.
+  "Process to fetch group and its notes.
 
-DATA はリクエスト成功時の JSON."
+DATA is the JSON from a successful request."
   (let* ((row-data (assoc-default 'data data))
          (row-group (assoc-default 'group row-data))
          (row-notes (assoc-default 'notes row-group))

--- a/kibela.el
+++ b/kibela.el
@@ -459,8 +459,7 @@ MARKER contains the cursor position in the note list."
 (define-derived-mode
   kibela-list-mode
   tabulated-list-mode
-  "Kibela list"
-  "Major mode for browsing Kibela notes list.\n\n\\{kibela-list-mode-map}"
+  "Kibela list view."
   (setq tabulated-list-format [("Title" 40 t) ("UpdatedAt" 20 t)])
   (setq tabulated-list-sort-key '("UpdatedAt" . t))
   (add-hook 'tabulated-list-revert-hook 'kibela-group-notes-refresh nil t)

--- a/kibela.el
+++ b/kibela.el
@@ -172,7 +172,7 @@ Used for pagination.")
      (groups id name)
      (folders
       :arguments ((first . 100)) (edges (node id fullName (group id name)))))))
-  "Note を取得するためのクエリ.")
+  "Query to retrieve a Note.")
 
 (defconst kibela-graphql-query-default-group
   (graphql-query ((defaultGroup id name)))

--- a/kibela.el
+++ b/kibela.el
@@ -403,15 +403,15 @@ DATA is the JSON from a successful request."
     (tabulated-list-print)))
 
 (defun kibela-note-show-from-list (marker)
-  "記事一覧から記事を開くためのアクション.
+  "Action to open a note from the list.
 
-MARKER には記事一覧のカーソル位置が渡されてくる."
+MARKER contains the cursor position in the note list."
   (let* ((pos (marker-position marker))
          (id (get-text-property pos 'id)))
     (kibela-note-show id)))
 
 (defun kibela-group-notes-refresh ()
-  "記事一覧を読み込み直す処理."
+  "Process to reload the note list."
   (message "Fetch default group notes...")
   (let* ((group-id (assoc-default 'id kibela-default-group))
          (query kibela-graphql-query-group-notes-next)
@@ -419,7 +419,7 @@ MARKER には記事一覧のカーソル位置が渡されてくる."
     (kibela--request query variables #'kibela--group-notes-success)))
 
 (defun kibela-group-notes-next-page ()
-  "記事一覧で次のページを取得する処理."
+  "Process to fetch the next page of notes."
   (interactive)
   (cond
    (kibela-has-next-page
@@ -434,7 +434,7 @@ MARKER には記事一覧のカーソル位置が渡されてくる."
     (message "Current page is last"))))
 
 (defun kibela-group-notes-prev-page ()
-  "記事一覧で前のページを取得する処理."
+  "Process to fetch the previous page of notes."
   (interactive)
   (cond
    (kibela-has-prev-page
@@ -460,7 +460,7 @@ MARKER には記事一覧のカーソル位置が渡されてくる."
   kibela-list-mode
   tabulated-list-mode
   "Kibela list"
-  "Kibela list view."
+  "Major mode for browsing Kibela notes list.\n\n\\{kibela-list-mode-map}"
   (setq tabulated-list-format [("Title" 40 t) ("UpdatedAt" 20 t)])
   (setq tabulated-list-sort-key '("UpdatedAt" . t))
   (add-hook 'tabulated-list-revert-hook 'kibela-group-notes-refresh nil t)
@@ -586,7 +586,7 @@ DATA はリクエスト成功時の JSON."
 
 ;;;###autoload
 (defun kibela-recent-browsing-notes ()
-  "最近見た記事一覧を開くコマンド."
+  "Command to open the list of recently viewed notes."
   (interactive)
   (unless (and kibela-team kibela-access-token)
     (kibela-switch-team))

--- a/kibela.el
+++ b/kibela.el
@@ -191,7 +191,7 @@ Used for pagination.")
        content
        (groups id name)
        (folders id fullName evaluatedFullName (group id name)))))))
-  "記事テンプレート一覧を取得するクエリ.")
+  "Query to retrieve a list of note templates.")
 
 (defconst kibela-graphql-mutation-create-note
   (graphql-mutation

--- a/kibela.el
+++ b/kibela.el
@@ -64,7 +64,7 @@ Used when creating a note from a template.")
   "Variable to store whether the note can be updated.")
 
 (defvar-local kibela-note-id nil
-  "記事 ID を保存する変数.")
+  "Variable to store the note ID.")
 
 (defvar-local kibela-note-url nil
   "記事 URL を保存する変数.")

--- a/kibela.el
+++ b/kibela.el
@@ -236,11 +236,11 @@ Used for pagination.")
     ("Authorization" . ,(concat "Bearer " kibela-access-token))))
 
 (defun kibela--request (query variables success)
-  "Kibela へのリクエストを飛ばすための関数.
+  "Function to send requests to Kibela.
 
-QUERY は GraphQL のクエリで
-VARIABLES は GraphQL の Variables.
-SUCCESS はリクエストが成功した時の処理."
+QUERY is the GraphQL query.
+VARIABLES are the GraphQL variables.
+SUCCESS is the handler for when the request succeeds."
   (let ((data (json-encode `((query . ,query) (variables . ,variables)))))
     (request
       (kibela-endpoint)

--- a/kibela.el
+++ b/kibela.el
@@ -735,7 +735,7 @@ TEMPLATE は記事作成時に利用するテンプレート."
     (setq kibela-note-template template)))
 
 (defun kibela-note-create ()
-  "記事作成."
+  "Create a note."
   (interactive)
   (let* ((query kibela-graphql-mutation-create-note)
          (buffer-content (substring-no-properties (buffer-string)))

--- a/kibela.el
+++ b/kibela.el
@@ -107,8 +107,8 @@ Used to advance to the next page.")
       (edges
        cursor
        (node id title content contentUpdatedAt coediting canBeUpdated url))))))
-  "グループ配下の指定した記事よりも前の記事を取得するためのクエリ.
-グループの記事一覧のページ送りで利用している")
+  "Query to retrieve notes preceding the specified note within a group.
+Used for pagination in the group's note list.")
 
 (defconst kibela-graphql-query-group-notes-next
   (graphql-query


### PR DESCRIPTION
## 変更内容
- カスタム変数、定数、関数のドキュメント文字列を日本語から英語に翻訳
- 既存のコード構造と機能は変更せず説明文のみ更新
- 翻訳は1説明文ごとに個別コミットを実施

## 影響範囲
- 開発者向けドキュメンテーションのみの変更
- 実際の機能やユーザー向けインターフェースに変更なし