### PR TITLE
refactor: extract authentication logic

### DIFF
--- a/Eask
+++ b/Eask
@@ -8,7 +8,8 @@
 (keywords "kibela" "tools")
 
 (package-file "kibela.el")
-(files "kibela-markdown-mode.el"
+(files "kibela-auth.el"
+       "kibela-markdown-mode.el"
        "kibela-request.el")
 
 (script "test" "echo \"Error: no test specified\" && exit 1")

--- a/kibela-auth.el
+++ b/kibela-auth.el
@@ -1,0 +1,60 @@
+;;; kibela-auth.el --- Kibela authentication -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Mugijiru
+
+;; Author: mugijiru <106833+mugijiru@users.noreply.github.com>
+;; Maintainer: mugijiru <106833+mugijiru@users.noreply.github.com>
+;; URL: https://github.com/mugijiru/emacs-kibela
+;; Version: 2.0.0
+;; Keywords: kibela, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Kibela authentication module
+
+;;; Code:
+
+(defcustom kibela-auth-list nil
+  "Authentication information for Kibela.
+Each element has the form (NAME TEAM ACCESS-TOKEN)."
+  :group 'kibela
+  :type '(alist :value-type (string string string)))
+
+(defvar kibela-team nil
+  "Kibela team name for login.")
+
+(defvar kibela-access-token nil
+  "Kibela access token for login.")
+
+;;;###autoload
+(defun kibela-switch-team ()
+  "Switch between teams to operate."
+  (interactive)
+  (let* ((selected (completing-read "Select team: " kibela-auth-list))
+         (auth (assoc-default selected kibela-auth-list))
+         (team (cl-first auth))
+         (access-token (cl-second auth)))
+    (cond
+     (auth
+      (kill-matching-buffers "\\*Kibela\\*" nil t)
+      (setq kibela-team team)
+      (setq kibela-access-token access-token)
+      (setq kibela-default-group nil))
+     (t
+      (message "No match team.")))))
+
+(provide 'kibela-auth)
+;;; kibela-auth.el ends here

--- a/kibela-auth.el
+++ b/kibela-auth.el
@@ -27,6 +27,8 @@
 
 ;;; Code:
 
+(defvar kibela-default-group)
+
 (defcustom kibela-auth-list nil
   "Authentication information for Kibela.
 Each element has the form (NAME TEAM ACCESS-TOKEN)."

--- a/kibela.el
+++ b/kibela.el
@@ -32,23 +32,13 @@
 (require 'request)
 (require 'json)
 (require 'tabulated-list)
+(require 'kibela-auth)
 (require 'kibela-request)
 (require 'kibela-markdown-mode)
 
 (defvar tabulated-list-format)
 (defvar tabulated-list-sort-key)
 
-(defcustom kibela-auth-list nil
-  "Authentication information for Kibela.
-Each element has the form (NAME TEAM ACCESS-TOKEN)."
-  :group 'kibela
-  :type '(alist :value-type (string string string)))
-
-(defvar kibela-team nil
-  "Kibela team name for login.")
-
-(defvar kibela-access-token nil
-  "Kibela access token for login.")
 
 (defvar-local kibela-note-base nil
   "Holds the state of the note when it was retrieved.
@@ -226,22 +216,6 @@ Used for pagination.")
      (likers :arguments ((first . 100)) (totalCount) (edges (node id))))))
   "Query to unlike a note.")
 
-;;;###autoload
-(defun kibela-switch-team ()
-  "Switch between teams to operate."
-  (interactive)
-  (let* ((selected (completing-read "Select team: " kibela-auth-list))
-         (auth (assoc-default selected kibela-auth-list))
-         (team (cl-first auth))
-         (access-token (cl-second auth)))
-    (cond
-     (auth
-      (kill-matching-buffers "\\*Kibela\\*" nil t)
-      (setq kibela-team team)
-      (setq kibela-access-token access-token)
-      (setq kibela-default-group nil))
-     (t
-      (message "No match team.")))))
 
 (cl-defun
     kibela--store-default-group-success (&key data &allow-other-keys)


### PR DESCRIPTION
kibela.el を小さくしていくため
認証関連のロジックを kibela-auth.el に切り出しました。